### PR TITLE
SE-2114 SSL update

### DIFF
--- a/nested/customdomain.json
+++ b/nested/customdomain.json
@@ -48,7 +48,10 @@
                 "hostNameType": "Verified",
                 "sslState": "SniEnabled",
                 "thumbprint":"[reference(resourceId('Microsoft.Web/certificates', parameters('customDomainsWithCerts')[copyIndex()].certificateName)).Thumbprint]"
-            }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/certificates', parameters('customDomainsWithCerts')[copyIndex()].certificateName)]"
+            ]
         }
     ]
 }

--- a/nested/customdomain.json
+++ b/nested/customdomain.json
@@ -12,6 +12,10 @@
             "type": "array",
             "defaultValue": []
         },
+        "sslCertificates": {
+            "type": "array",
+            "defaultValue": []
+        },
         "existingKeyVaultId": {
             "type": "string"
         }
@@ -19,16 +23,16 @@
     "resources": [
         {
             "type":"Microsoft.Web/certificates",
-            "name":"[parameters('customDomainsWithCerts')[copyIndex()].certificateName]",
+            "name":"[parameters('sslCertificates')[copyIndex()].certificateName]",
             "apiVersion":"2016-03-01",
             "location":"[resourceGroup().location]",
             "copy": {
                 "name": "domains",
-                "count": "[length(parameters('customDomainsWithCerts'))]"
+                "count": "[length(parameters('sslCertificates'))]"
             },
             "properties":{
                 "keyVaultId": "[parameters('existingKeyVaultId')]",
-                "keyVaultSecretName":"[parameters('customDomainsWithCerts')[copyIndex()].certificateSecretName]",
+                "keyVaultSecretName":"[parameters('sslCertificates')[copyIndex()].certificateSecretName]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverFarms',parameters('serverfarms_serviceplan_name'))]"
             }
         },

--- a/nested/website.json
+++ b/nested/website.json
@@ -57,6 +57,10 @@
             "type": "array",
             "defaultValue": []
         },
+        "sslCertificates": {
+            "type": "array",
+            "defaultValue": []
+        },
         "appInsightsInstrumentationKey": {
             "type": "securestring"
         },
@@ -294,6 +298,9 @@
                 "parameters": {
                    "customDomainsWithCerts": {
                         "value": "[parameters('customDomainsWithCerts')]"
+                    },
+                    "sslCertificates": {
+                        "value": "[parameters('sslCertificates')]"
                     },
                     "existingKeyVaultId": {
                         "value": "[parameters('existingKeyVaultId')]"

--- a/template.json
+++ b/template.json
@@ -251,6 +251,10 @@
             "type": "string",
             "defaultValue": ""
         },
+        "sslCertificates": {
+            "type": "array",
+            "defaultValue": []
+        },
         "customDomainsWithCerts": {
             "type": "array",
             "defaultValue": []
@@ -823,6 +827,9 @@
                     },
                     "customDomainsWithCerts": {
                         "value": "[parameters('customDomainsWithCerts')]"
+                    },
+                    "sslCertificates": {
+                        "value": "[parameters('sslCertificates')]"
                     },
                     "existingKeyVaultId": {
                         "value": "[resourceId(parameters('vaultResourceGroupName'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"


### PR DESCRIPTION
Updated SSL handling to separate certificate list from binding list.

We cannot update the 'in-use' certificate within Azure. The solution is to 'add' a second certificate, then update the App Service hostname binding to use the 'new' certificate.

This requires that we can install both new and old certificates, but update a single hostname binding.

Changes
1. Restructure the template to use separate variables for the certificate list from the hostname binding list